### PR TITLE
add support for clear-site-data

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The supported security headers include:
 - X-Download-Options - [Prevent file downloads opening](http://msdn.microsoft.com/en-us/library/ie/jj542450(v=vs.85).aspx)
 - X-Permitted-Cross-Domain-Policies - [Restrict Adobe Flash Player's access to data](https://www.adobe.com/devnet/adobe-media-server/articles/cross-domain-xml-for-streaming.html)
 - Public Key Pinning - Pin certificate fingerprints in the browser to prevent man-in-the-middle attacks due to compromised Certificate Authorities. [Public Key Pinning  Specification](https://tools.ietf.org/html/rfc7469)
+- Clear-Site-Data - Clearing browser data for origin. [Clear-Site-Data specification](https://w3c.github.io/webappsec-clear-site-data/).
 
 ## Installation
 
@@ -47,7 +48,8 @@ config secure_headers:, SecureHeaders,
       x_download_options: "noopen", 
       x_frame_options: "sameorigin", 
       x_permitted_cross_domain_policies: "none", 
-      x_xss_protection: "1; mode=block"
+      x_xss_protection: "1; mode=block",
+      clear_client_data: "cache"
   ]
 ]
 ```
@@ -91,6 +93,7 @@ defmodule SecurePhoenixApp.SecureController do
     X-Permitted-Cross-Domain-Policies:     #{conn.assigns[:x_permitted_cross_domain_policies]}  
     X-XSS-Protection:                      #{conn.assigns[:x_xss_protection]}
     Public Key Pinning:                    #{conn.assigns[:http_public_key_pins]}     
+    Clear-Site-Data:                       #{conn.assigns[:clear_site_data]}
 
     """
     end

--- a/README.md
+++ b/README.md
@@ -48,8 +48,7 @@ config secure_headers:, SecureHeaders,
       x_download_options: "noopen", 
       x_frame_options: "sameorigin", 
       x_permitted_cross_domain_policies: "none", 
-      x_xss_protection: "1; mode=block",
-      clear_client_data: "cache"
+      x_xss_protection: "1; mode=block"
   ]
 ]
 ```

--- a/lib/headers/clear_site_data.ex
+++ b/lib/headers/clear_site_data.ex
@@ -1,0 +1,42 @@
+defmodule SecureHeaders.ClearSiteData do
+  
+  # https://w3c.github.io/webappsec-clear-site-data/
+
+  @error_msg "Invalid configuration for clear-site-data"  
+  @valid_header ~r/\A(cache\z|cookies\z|storage\z|executioncontexts)/i
+
+  def validate(options) when is_list(options) do
+    case Keyword.has_key?(options, :config) do 
+      false -> {:ok, options}
+      true  -> 
+      case Keyword.has_key?(options[:config], :clear_site_data) do
+        # No clear_site_data configuration found - return config
+        false -> {:ok, options}
+        true  -> 
+          case validate_config(options[:config]) do
+            false -> {:error, @error_msg}
+            true  -> {:ok, options}
+          end
+      end
+    end
+  end  
+  
+  def validate(_),  do: {:error, @error_msg}
+
+  defp validate_config(config) when config |> is_list do
+    validate_value(config[:clear_site_data])
+  end
+
+  defp validate_config(config) when config |> is_boolean do
+    validate_value(config[:clear_site_data])
+  end
+
+  defp validate_value(config) when config |> is_bitstring do
+    Regex.match?( @valid_header, config)
+  end
+  
+  defp validate_value(config) do
+    !config
+  end
+
+end

--- a/lib/secure_headers.ex
+++ b/lib/secure_headers.ex
@@ -32,6 +32,7 @@ defmodule SecureHeaders do
       |> SecureHeaders.XFrameOptions.validate
       |> SecureHeaders.XPermittedCrossDomainPolicies.validate
       |> SecureHeaders.XXssProtection.validate
+      |> SecureHeaders.ClearSiteData.validate
   end
   
   defp set_headers(conn, options) when options |> is_list do

--- a/test/headers/clear_site_data_test.exs
+++ b/test/headers/clear_site_data_test.exs
@@ -1,0 +1,45 @@
+defmodule SecureHeaders.ClearSiteDataTest do
+  use ExUnit.Case, async: true
+  alias SecureHeaders.ClearSiteData
+  
+    
+  #
+  # test valid config
+  #
+  test "should allow string value 'cache'" do
+    assert {:ok, _} = ClearSiteData.validate([config: [clear_site_data: "cache"]])
+  end
+  
+  test "should allow string value 'cookies'" do
+    assert {:ok, _} = ClearSiteData.validate([config: [clear_site_data: "cookies"]])
+  end
+
+  test "should allow string value 'storage'" do
+    assert {:ok, _} = ClearSiteData.validate([config: [clear_site_data: "storage"]])
+  end
+
+  test "should allow string value 'executioncontexts'" do
+    assert {:ok, _} = ClearSiteData.validate([config: [clear_site_data: "executioncontexts"]])
+  end
+
+  test "should allow clear_site_data: false" do
+    assert {:ok, _} = ClearSiteData.validate([config: [clear_site_data: false]])
+  end
+  
+  test "should allow clear_site_data: nil" do
+    assert {:ok, _} = ClearSiteData.validate([config: [clear_site_data: nil]])
+  end
+  
+  #
+  # test invalid config with option [warn_only: true] (validate fails with {:error, msg})
+  #
+  test "validation fails if value is invalid as list (not 'noopen', nil, or false)" do
+     assert {:error, "Invalid configuration for clear-site-data"} = 
+            ClearSiteData.validate([warn_only: true, config: [clear_site_data: "INVALID_CONFIG"]])
+  end
+  
+  test "validation fails if value is true as list (not 'noopen', nil, or false)" do
+     assert {:error, "Invalid configuration for clear-site-data"} =
+            ClearSiteData.validate([warn_only: true, config: [clear_site_data: true]])
+  end
+end

--- a/test/secure_headers_test.exs
+++ b/test/secure_headers_test.exs
@@ -20,7 +20,8 @@ defmodule SecureHeaders.SecureHeadersTest do
       {"x-download-options", "noopen"},
       {"x-frame-options", "sameorigin"},
       {"x-permitted-cross-domain-policies", "none"},
-      {"x-xss-protection", "1; mode=block"}
+      {"x-xss-protection", "1; mode=block"},
+      {"clear-site-data", "cache"}
     ]
   end
 
@@ -59,14 +60,14 @@ defmodule SecureHeaders.SecureHeadersTest do
     assert response.status == Status.code(:ok)
     assert response.resp_headers ==  [
       {"cache-control", "max-age=0, private, must-revalidate"}, 
-      {"content-security-policy", "default-src 'none';"}, 
       {"http-public-key-pins", ""}, 
       {"strict-transport-security", "max-age=631138519"}, 
       {"x-content-type-options", "nosniff"}, 
       {"x-download-options", "noopen"}, 
       {"x-frame-options", "sameorigin"}, 
       {"x-permitted-cross-domain-policies", "none"}, 
-      {"x-xss-protection", "1; mode=block"}
+      {"x-xss-protection", "1; mode=block"},
+      {"content-security-policy", "default-src 'none';"}
     ]
   end
 

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -26,7 +26,8 @@ defmodule TestApp do
       x_download_options: "noopen", 
       x_frame_options: "sameorigin", 
       x_permitted_cross_domain_policies: "none", 
-      x_xss_protection: "1; mode=block"
+      x_xss_protection: "1; mode=block",
+      clear_site_data: "cache"
     ]
   ] 
 	use AppMaker, secure_headers: @secure_config


### PR DESCRIPTION
this PR adds support for the draft "clear-site-data" (CSD) header standard. (noticed in part because of its inclusion in twitter/secureheaders for rails). 

this does not include any changes to the default headers, CSD should only be used for logout or similar "please destroy records of our data" type events. 