### PR TITLE
Fix semicolon placement

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ SecureHeaders by design defaults to a strict security policy.  If no opts are su
 the following secure configuration:
 
 ```elixir
-config secure_headers:, SecureHeaders, 
+config :secure_headers, SecureHeaders, 
   config: [
       content_security_policy: "default-src 'none'; script-src 'self'; connect-src 'self'; img-src 'self'; style-src 'self';", 
       http_public_key_pins: "", 
@@ -50,7 +50,6 @@ config secure_headers:, SecureHeaders,
       x_permitted_cross_domain_policies: "none", 
       x_xss_protection: "1; mode=block"
   ]
-]
 ```
 
 ```elixir


### PR DESCRIPTION
  The configuration provided in the README file has a syntax error